### PR TITLE
Fix plugin to work correctly on Windows

### DIFF
--- a/external-module-map-plugin.ts
+++ b/external-module-map-plugin.ts
@@ -144,7 +144,7 @@ export class ExternalModuleMapPlugin extends ConverterComponent {
     this.modules.forEach((name: string) => {
       let ref = refsArray
         .filter(ref => ref.name === name)
-        .find(ref => ref.originalName[0] === '/') as ContainerReflection;
+        .find(ref => path.isAbsolute(ref.originalName)) as ContainerReflection;
       let root = ref.originalName.replace(new RegExp(`${name}.*`, 'gi'), name);
       try {
         // tslint:disable-next-line ban-types


### PR DESCRIPTION
Fixing what I assume was intended to be a check for an absolute path, however Windows paths start with a drive letter. Running this plugin on Windows resulted in the following exception:
```
TypeError: Cannot read property 'originalName' of undefined
    at C:\dev\esfx\node_modules\@strictsoftware\typedoc-plugin-monorepo\dist\external-module-map-plugin.js:134:32
    at Set.forEach (<anonymous>)
    at ExternalModuleMapPlugin.onBeginResolve (C:\dev\esfx\node_modules\@strictsoftware\typedoc-plugin-monorepo\dist\external-module-map-plugin.js:130:26)
    at triggerEvents (C:\dev\esfx\node_modules\typedoc\src\lib\utils\events.ts:238:61)
    at triggerApi (C:\dev\esfx\node_modules\typedoc\src\lib\utils\events.ts:219:13)
    at eventsApi (C:\dev\esfx\node_modules\typedoc\src\lib\utils\events.ts:96:18)
    at Converter.trigger (C:\dev\esfx\node_modules\typedoc\src\lib\utils\events.ts:497:13)
    at Converter.resolve (C:\dev\esfx\node_modules\typedoc\src\lib\converter\converter.ts:429:14)
    at Converter.convert (C:\dev\esfx\node_modules\typedoc\src\lib\converter\converter.ts:295:30)
    at Application.convert (C:\dev\esfx\node_modules\typedoc\src\lib\application.ts:161:39)
```

This PR switches the check to use `path.isAbsolute` which performs the correct check based on the current platform.